### PR TITLE
Bump rand crate {0.3 => 0.4}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ libc = "0.2.0"
 
 [dev-dependencies]
 chacha20-poly1305-aead = "0.1"
-rand = "0.3"
+rand = "0.4"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
This PR bumps the version of the `rand` crate to 0.4. ([changelog](https://github.com/rust-lang-nursery/rand/blob/master/CHANGELOG.md#040-pre0---2017-12-11))