### PR TITLE
Add have_libsodium feature to disable internal randombytes implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ description = "Shamir secret sharing library for Rust"
 license = "MIT"
 repository = "https://github.com/dsprenkels/sss-rs"
 
+[features]
+have_libsodium = []
+
 [dependencies]
 libc = "0.2.0"
 

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,10 @@
 extern crate cc;
 
 fn main() {
+    #[cfg(not(feature="have_libsodium"))]
     let sources = ["sss/sss.c", "sss/hazmat.c", "sss/randombytes.c", "sss/tweetnacl.c"];
+    #[cfg(feature="have_libsodium")]
+    let sources = ["sss/sss.c", "sss/hazmat.c", "sss/tweetnacl.c"];
     cc::Build::new()
         .files(sources.iter())
         .flag("-Wno-sign-compare") // Suppress sign warnings in tweetnacl.c


### PR DESCRIPTION
As recommended in the readme, when libsodium is used we should probably use its randombytes implementation. This adds a feature to the create to disable the internal randombytes implementation. 

