### PR TITLE
Update the dependencies and move to crypto_secretbox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ documentation = "https://docs.rs/shamirsecretsharing"
 license = "MIT"
 name = "shamirsecretsharing"
 repository = "https://github.com/dsprenkels/sss-rs"
-version = "0.1.5"
+version = "0.1.6"
 
 [badges]
 maintenance = {status = "passively-maintained"}
@@ -18,11 +18,8 @@ travis-ci = {repository = "dsprenkels/sss-rs", branch = "master"}
 have_libsodium = []
 
 [dependencies]
-rand = "0.8"
-xsalsa20poly1305 = "0.6"
+rand = "0.8.5"
+xsalsa20poly1305 = "0.8"
 
 [dev-dependencies]
 chacha20-poly1305-aead = "0.1"
-
-[build-dependencies]
-cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ documentation = "https://docs.rs/shamirsecretsharing"
 license = "MIT"
 name = "shamirsecretsharing"
 repository = "https://github.com/dsprenkels/sss-rs"
-version = "0.1.6"
+version = "0.1.7"
 
 [badges]
 maintenance = {status = "passively-maintained"}
@@ -19,7 +19,7 @@ have_libsodium = []
 
 [dependencies]
 rand = "0.8.5"
-xsalsa20poly1305 = "0.8"
+crypto_secretbox = "0.1"
 
 [dev-dependencies]
 chacha20-poly1305-aead = "0.1"


### PR DESCRIPTION
- xsalsa20poly1305 has been recently deprecated in favor of crypto_secretbox (It is mostly a drop-in replacement.)
- Update to the latest version of rand (perhaps unnecessarily)
- Remove the remnants of the time when there was a C library underneath.